### PR TITLE
fix error C2039: 'runtime_error': is not a member of 'std'

### DIFF
--- a/src/base64.cpp
+++ b/src/base64.cpp
@@ -1,5 +1,6 @@
 #include <array>
 #include <cstring>
+#include <stdexcept>
 
 #include "base64.h"
 


### PR DESCRIPTION
https://pipelines.actions.githubusercontent.com/f4zMuodMiyI623NgrPVBAS9kRdVwmOCb2EUpxlMfXj3Ont86aE/_apis/pipelines/1/runs/294/signedlogcontent/12?urlExpires=2020-06-17T21%3A37%3A12.2910937Z&urlSigningMethod=HMACV1&urlSignature=Rew2x9I1alfWDJRnH3KTL1kc34cTP%2BwiGkz%2FQcGeo0o%3D