### PR TITLE
add support for proxy settings

### DIFF
--- a/include/blob/blob_client.h
+++ b/include/blob/blob_client.h
@@ -54,6 +54,33 @@ namespace azure { namespace storage_lite {
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="azure::storage_lite::blob_client" /> class.
+        /// </summary>
+        /// <param name="account">An existing <see cref="azure::storage_lite::storage_account" /> object.</param>
+        /// <param name="max_concurrency">An int value indicates the maximum concurrency expected during execute requests against the service.</param>
+        /// <param name="ca_path">A string value with absolute path to CA bundle location.</param>
+        /// <param name="proxy_host">A string value with proxy host in format http://host or https://host.</param>
+        /// <param name="proxy_port">A unsigned int value with proxy port number.</param>
+        /// <param name="proxy_user">A string value with proxy user name.</param>
+        /// <param name="proxy_password">A string value with proxy user password.</param>
+        /// <param name="no_proxy">A string value with a host list don't require proxy.</param>
+        blob_client(std::shared_ptr<storage_account> account,
+                    int max_concurrency,
+                    const std::string& ca_path,
+                    const std::string& proxy_host,
+                    unsigned proxy_port,
+                    const std::string& proxy_user,
+                    const std::string& proxy_password,
+                    const std::string& no_proxy)
+            : m_account(account)
+        {
+            m_context = std::make_shared<executor_context>(std::make_shared<tinyxml2_parser>(), std::make_shared<retry_policy>());
+            m_client = std::make_shared<CurlEasyClient>(
+                           max_concurrency, ca_path, proxy_host, proxy_port,
+                           proxy_user, proxy_password, no_proxy);
+        }
+
+        /// <summary>
         /// Gets the curl client used to execute requests.
         /// </summary>
         /// <returns>The <see cref="azure::storage_lite::CurlEasyClient"> object</returns>

--- a/include/http/libcurl_http_client.h
+++ b/include/http/libcurl_http_client.h
@@ -305,6 +305,36 @@ namespace azure {  namespace storage_lite {
             }
         }
 
+        //Sets CURL CA BUNDLE location and proxy settings for all the curl handlers.
+        CurlEasyClient(int size,
+                       const std::string& ca_path,
+                       const std::string& proxy_host,
+                       unsigned proxy_port,
+                       const std::string& proxy_user,
+                       const std::string& proxy_password,
+                       const std::string& no_proxy
+                       ) : m_size(size), m_caPath(ca_path)
+        {
+            curl_global_init(CURL_GLOBAL_DEFAULT);
+            for (int i = 0; i < m_size; i++) {
+                CURL *h = curl_easy_init();
+                curl_easy_setopt(h, CURLOPT_CAINFO, m_caPath.c_str());
+                if (proxy_host.empty())
+                {
+                  curl_easy_setopt(h, CURLOPT_PROXY, "");
+                }
+                else
+                {
+                  curl_easy_setopt(h, CURLOPT_PROXY, proxy_host.c_str());
+                  curl_easy_setopt(h, CURLOPT_PROXYPORT, (long) proxy_port);
+                  curl_easy_setopt(h, CURLOPT_PROXYUSERNAME, proxy_user.c_str());
+                  curl_easy_setopt(h, CURLOPT_PROXYPASSWORD, proxy_password.c_str());
+                  curl_easy_setopt(h, CURLOPT_NOPROXY, no_proxy.c_str());
+                }
+                m_handles.push(h);
+            }
+        }
+
         ~CurlEasyClient() {
             while (!m_handles.empty())
             {


### PR DESCRIPTION
Fix for ODBC proxy issue. So far the ODBC driver pass down proxy settings through environment variables, which would affect all connections in the same process. The customer who report this issue is using multi-threading to handling connections from different users, which would need different proxy setting for each connection.
Add proxy settings for azure api so the odbc driver can use that to pass down proxy settings from connection string.