### PR TITLE
Bug fix for multi-parts uploading with file size larger than 2GB

### DIFF
--- a/src/blob/blob_client_wrapper.cpp
+++ b/src/blob/blob_client_wrapper.cpp
@@ -395,7 +395,9 @@ namespace azure {  namespace storage_lite {
                 return;
             }
 
-            off_t fileSize = streamlen;
+            // used to be off_t which was 4 bytes on Windows
+            // Change to long long to fix the issue with file size larger than 2GB
+            long long fileSize = streamlen;
             if(fileSize < 0)
             {
                 /*errno already set by get_file_size*/


### PR DESCRIPTION
Simba ticket 00390901
Put command failed when file size is larger than 2GB.
Root cause: There are several places in libsnowflakeclient using long type variables for file size/offset, while long is 4 bytes on Windows and could cause data overflow when file size is larger than 2GB.
There is one in azure as well.
Will create a PR on libsnowflakeclient side and test will be added there.